### PR TITLE
Add reusable Go dependency diff workflow

### DIFF
--- a/.github/workflows/go-dependency-diff.yaml
+++ b/.github/workflows/go-dependency-diff.yaml
@@ -77,6 +77,7 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_BASE_REF: ${{ inputs.base-ref }}
+          INPUT_FAIL_ON_CHANGES: ${{ inputs.fail-on-changes }}
           INPUT_GO_MOD_FILE: ${{ inputs.go-mod-file }}
           INPUT_HEAD_REF: ${{ inputs.head-ref }}
           GOTOOLCHAIN: ${{ inputs.go-toolchain }}
@@ -287,9 +288,7 @@ jobs:
             (if (.updated | length) == 0 then "_None_" else (.updated[] | "- `\(.module)` `\(.from)` → `\(.to)`") end)
           ' "$tmp_dir/report.json" >>"$GITHUB_STEP_SUMMARY"
 
-      - name: Reject dependency changes
-        if: ${{ inputs.fail-on-changes && steps.diff.outputs.has_changes == 'true' }}
-        shell: sh
-        run: |
-          echo "Direct Go dependency changes were detected." >&2
-          exit 1
+          if [[ "$INPUT_FAIL_ON_CHANGES" == true && "$has_changes" == true ]]; then
+            echo "Direct Go dependency changes were detected." >&2
+            exit 1
+          fi

--- a/.github/workflows/go-dependency-diff.yaml
+++ b/.github/workflows/go-dependency-diff.yaml
@@ -1,0 +1,243 @@
+name: Go dependency diff
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+        required: false
+        default: '"ubuntu-latest"'
+        description: JSON runner label or label array passed to runs-on
+      go-version:
+        type: string
+        required: false
+        default: 1.26.5
+        description: Go version used to parse the module files
+      go-toolchain:
+        type: string
+        required: false
+        default: auto
+        description: GOTOOLCHAIN environment variable for Go commands
+      go-mod-file:
+        type: string
+        required: false
+        default: go.mod
+        description: Repository-relative path to the Go module file
+      base-ref:
+        type: string
+        required: false
+        default: ''
+        description: Base Git ref or SHA; defaults to the pull request base SHA
+      head-ref:
+        type: string
+        required: false
+        default: ''
+        description: Head Git ref or SHA; defaults to the pull request head SHA or GITHUB_SHA
+      fail-on-changes:
+        type: boolean
+        required: false
+        default: false
+        description: Fail when direct Go dependencies changed
+    outputs:
+      has_changes:
+        description: Whether direct Go dependencies changed
+        value: ${{ jobs.dependency-diff.outputs.has_changes }}
+      report_json:
+        description: Direct Go dependency differences as compact JSON
+        value: ${{ jobs.dependency-diff.outputs.report_json }}
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-diff:
+    name: Compare direct Go dependencies
+    runs-on: ${{ fromJSON(inputs.runner) }}
+    timeout-minutes: 5
+    outputs:
+      has_changes: ${{ steps.diff.outputs.has_changes }}
+      report_json: ${{ steps.diff.outputs.report_json }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up go
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ inputs.go-version }}
+          cache: false
+
+      - name: Compare direct dependencies
+        id: diff
+        shell: bash
+        env:
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INPUT_BASE_REF: ${{ inputs.base-ref }}
+          INPUT_GO_MOD_FILE: ${{ inputs.go-mod-file }}
+          INPUT_HEAD_REF: ${{ inputs.head-ref }}
+          GOTOOLCHAIN: ${{ inputs.go-toolchain }}
+        run: |
+          set -euo pipefail
+
+          base_ref="${INPUT_BASE_REF:-$EVENT_BASE_SHA}"
+          head_ref="${INPUT_HEAD_REF:-${EVENT_HEAD_SHA:-$GITHUB_SHA}}"
+          go_mod_file="$INPUT_GO_MOD_FILE"
+
+          if [[ -z "$base_ref" ]]; then
+            echo "Base ref is required outside a pull request." >&2
+            exit 1
+          fi
+
+          if [[ ! "$go_mod_file" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "Go module path contains unsupported characters: $go_mod_file" >&2
+            exit 1
+          fi
+
+          case "/$go_mod_file/" in
+            *"/./"*|*"/../"*)
+              echo "Go module path must not contain dot segments: $go_mod_file" >&2
+              exit 1
+              ;;
+          esac
+
+          case "$go_mod_file" in
+            /*|*/|*//* )
+              echo "Go module path must be a normalized repository-relative file: $go_mod_file" >&2
+              exit 1
+              ;;
+          esac
+
+          resolve_commit() {
+            local label="$1"
+            local ref="$2"
+            local commit
+
+            if ! commit="$(git rev-parse --verify --end-of-options "${ref}^{commit}" 2>/dev/null)"; then
+              echo "$label ref is unavailable: $ref" >&2
+              return 1
+            fi
+
+            if [[ ! "$commit" =~ ^[0-9a-f]+$ ]]; then
+              echo "$label ref did not resolve to a commit: $ref" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$commit"
+          }
+
+          base_commit="$(resolve_commit Base "$base_ref")"
+          head_commit="$(resolve_commit Head "$head_ref")"
+
+          for revision in "$base_commit" "$head_commit"; do
+            if ! git cat-file -e "${revision}:${go_mod_file}" 2>/dev/null; then
+              echo "$go_mod_file does not exist at commit $revision" >&2
+              exit 1
+            fi
+          done
+
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          git show "${base_commit}:${go_mod_file}" >"$tmp_dir/base.mod"
+          git show "${head_commit}:${go_mod_file}" >"$tmp_dir/head.mod"
+
+          # Direct requirements omit Indirect from `go mod edit -json`, so
+          # `.Indirect != true` intentionally includes only direct modules.
+          go mod edit -json "$tmp_dir/base.mod" |
+            jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/base.json"
+
+          go mod edit -json "$tmp_dir/head.mod" |
+            jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/head.json"
+
+          jq -n \
+            --arg base_ref "$base_ref" \
+            --arg base_commit "$base_commit" \
+            --arg head_ref "$head_ref" \
+            --arg head_commit "$head_commit" \
+            --arg go_mod_file "$go_mod_file" \
+            --slurpfile base "$tmp_dir/base.json" \
+            --slurpfile head "$tmp_dir/head.json" '
+              ($base[0] | map({key: .Path, value: .Version}) | from_entries) as $base_modules |
+              ($head[0] | map({key: .Path, value: .Version}) | from_entries) as $head_modules |
+              {
+                base_ref: $base_ref,
+                base_commit: $base_commit,
+                head_ref: $head_ref,
+                head_commit: $head_commit,
+                go_mod_file: $go_mod_file,
+                counts: {
+                  base_direct: ($base_modules | length),
+                  head_direct: ($head_modules | length),
+                  added: ([
+                    $head_modules | to_entries[] |
+                    select($base_modules[.key] == null)
+                  ] | length),
+                  removed: ([
+                    $base_modules | to_entries[] |
+                    select($head_modules[.key] == null)
+                  ] | length),
+                  updated: ([
+                    $head_modules | to_entries[] |
+                    select($base_modules[.key] != null and $base_modules[.key] != .value)
+                  ] | length)
+                },
+                added: [
+                  $head_modules | to_entries[] |
+                  select($base_modules[.key] == null) |
+                  {module: .key, version: .value}
+                ],
+                removed: [
+                  $base_modules | to_entries[] |
+                  select($head_modules[.key] == null) |
+                  {module: .key, version: .value}
+                ],
+                updated: [
+                  $head_modules | to_entries[] |
+                  select($base_modules[.key] != null and $base_modules[.key] != .value) |
+                  {module: .key, from: $base_modules[.key], to: .value}
+                ]
+              }
+            ' >"$tmp_dir/report.json"
+
+          has_changes="$(
+            jq -r '(.counts.added + .counts.removed + .counts.updated) > 0' \
+              "$tmp_dir/report.json"
+          )"
+
+          echo "has_changes=$has_changes" >>"$GITHUB_OUTPUT"
+          echo "report_json=$(jq -c . "$tmp_dir/report.json")" >>"$GITHUB_OUTPUT"
+
+          jq -r '
+            "## Direct Go dependency diff",
+            "",
+            "**Module file:** `\(.go_mod_file)`  ",
+            "**Base:** `\(.base_ref)` (`\(.base_commit)`)  ",
+            "**Head:** `\(.head_ref)` (`\(.head_commit)`)",
+            "",
+            "| Result | Count |",
+            "| --- | ---: |",
+            "| Base direct dependencies | \(.counts.base_direct) |",
+            "| Head direct dependencies | \(.counts.head_direct) |",
+            "| Added | \(.counts.added) |",
+            "| Removed | \(.counts.removed) |",
+            "| Updated | \(.counts.updated) |",
+            "",
+            "### Added",
+            (if (.added | length) == 0 then "_None_" else (.added[] | "- `\(.module)` `\(.version)`") end),
+            "",
+            "### Removed",
+            (if (.removed | length) == 0 then "_None_" else (.removed[] | "- `\(.module)` `\(.version)`") end),
+            "",
+            "### Updated",
+            (if (.updated | length) == 0 then "_None_" else (.updated[] | "- `\(.module)` `\(.from)` → `\(.to)`") end)
+          ' "$tmp_dir/report.json" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Reject dependency changes
+        if: ${{ inputs.fail-on-changes && steps.diff.outputs.has_changes == 'true' }}
+        shell: sh
+        run: |
+          echo "Direct Go dependency changes were detected." >&2
+          exit 1

--- a/.github/workflows/go-dependency-diff.yaml
+++ b/.github/workflows/go-dependency-diff.yaml
@@ -27,7 +27,7 @@ on:
         type: string
         required: false
         default: ''
-        description: Base Git ref or SHA; defaults to the pull request base SHA
+        description: Base ref or SHA; defaults to the PR base SHA and is a merge-base candidate on PRs
       head-ref:
         type: string
         required: false
@@ -75,6 +75,7 @@ jobs:
         env:
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
           INPUT_BASE_REF: ${{ inputs.base-ref }}
           INPUT_GO_MOD_FILE: ${{ inputs.go-mod-file }}
           INPUT_HEAD_REF: ${{ inputs.head-ref }}
@@ -89,15 +90,14 @@ jobs:
             fi
           done
 
-          merge_pr_base=false
-          if [[ -n "$INPUT_BASE_REF" ]]; then
-            base_ref="$INPUT_BASE_REF"
-          else
-            base_ref="$EVENT_BASE_SHA"
-            merge_pr_base=true
-          fi
+          base_ref="${INPUT_BASE_REF:-$EVENT_BASE_SHA}"
           head_ref="${INPUT_HEAD_REF:-${EVENT_HEAD_SHA:-$GITHUB_SHA}}"
           go_mod_file="$INPUT_GO_MOD_FILE"
+          base_is_merge_base=false
+
+          if [[ "$EVENT_NAME" == pull_request ]]; then
+            base_is_merge_base=true
+          fi
 
           if [[ -z "$base_ref" ]]; then
             echo "Base ref is required outside a pull request." >&2
@@ -143,10 +143,11 @@ jobs:
             printf '%s\n' "$commit"
           }
 
-          base_commit="$(resolve_commit Base "$base_ref")"
+          base_ref_commit="$(resolve_commit Base "$base_ref")"
+          base_commit="$base_ref_commit"
           head_commit="$(resolve_commit Head "$head_ref")"
 
-          if [[ "$merge_pr_base" == true ]]; then
+          if [[ "$base_is_merge_base" == true ]]; then
             if ! base_commit="$(git merge-base "$base_commit" "$head_commit")"; then
               echo "Base and head refs do not have a merge base." >&2
               exit 1
@@ -194,7 +195,9 @@ jobs:
 
           jq -n \
             --arg base_ref "$base_ref" \
+            --arg base_ref_commit "$base_ref_commit" \
             --arg base_commit "$base_commit" \
+            --argjson base_is_merge_base "$base_is_merge_base" \
             --arg head_ref "$head_ref" \
             --arg head_commit "$head_commit" \
             --arg go_mod_file "$go_mod_file" \
@@ -204,7 +207,9 @@ jobs:
               ($head[0] | map({key: .Path, value: .Version}) | from_entries) as $head_modules |
               {
                 base_ref: $base_ref,
+                base_ref_commit: $base_ref_commit,
                 base_commit: $base_commit,
+                base_is_merge_base: $base_is_merge_base,
                 head_ref: $head_ref,
                 head_commit: $head_commit,
                 go_mod_file: $go_mod_file,
@@ -254,7 +259,14 @@ jobs:
             "## Direct Go dependency diff",
             "",
             "**Module file:** `\(.go_mod_file)`  ",
-            "**Base:** `\(.base_ref)` (`\(.base_commit)`)  ",
+            (
+              if .base_is_merge_base then
+                "**Base candidate:** `\(.base_ref)` (`\(.base_ref_commit)`)  ",
+                "**Comparison base (merge base):** `\(.base_commit)`  "
+              else
+                "**Base:** `\(.base_ref)` (`\(.base_commit)`)  "
+              end
+            ),
             "**Head:** `\(.head_ref)` (`\(.head_commit)`)",
             "",
             "| Result | Count |",

--- a/.github/workflows/go-dependency-diff.yaml
+++ b/.github/workflows/go-dependency-diff.yaml
@@ -82,7 +82,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          base_ref="${INPUT_BASE_REF:-$EVENT_BASE_SHA}"
+          for command in git go jq; do
+            if ! command -v "$command" >/dev/null 2>&1; then
+              echo "Missing required command: $command" >&2
+              exit 1
+            fi
+          done
+
+          merge_pr_base=false
+          if [[ -n "$INPUT_BASE_REF" ]]; then
+            base_ref="$INPUT_BASE_REF"
+          else
+            base_ref="$EVENT_BASE_SHA"
+            merge_pr_base=true
+          fi
           head_ref="${INPUT_HEAD_REF:-${EVENT_HEAD_SHA:-$GITHUB_SHA}}"
           go_mod_file="$INPUT_GO_MOD_FILE"
 
@@ -116,8 +129,10 @@ jobs:
             local commit
 
             if ! commit="$(git rev-parse --verify --end-of-options "${ref}^{commit}" 2>/dev/null)"; then
-              echo "$label ref is unavailable: $ref" >&2
-              return 1
+              if ! commit="$(git rev-parse --verify --end-of-options "origin/${ref}^{commit}" 2>/dev/null)"; then
+                echo "$label ref is unavailable: $ref" >&2
+                return 1
+              fi
             fi
 
             if [[ ! "$commit" =~ ^[0-9a-f]+$ ]]; then
@@ -131,26 +146,51 @@ jobs:
           base_commit="$(resolve_commit Base "$base_ref")"
           head_commit="$(resolve_commit Head "$head_ref")"
 
-          for revision in "$base_commit" "$head_commit"; do
-            if ! git cat-file -e "${revision}:${go_mod_file}" 2>/dev/null; then
-              echo "$go_mod_file does not exist at commit $revision" >&2
+          if [[ "$merge_pr_base" == true ]]; then
+            if ! base_commit="$(git merge-base "$base_commit" "$head_commit")"; then
+              echo "Base and head refs do not have a merge base." >&2
               exit 1
             fi
-          done
+          fi
+
+          base_type="$(git cat-file -t "${base_commit}:${go_mod_file}" 2>/dev/null || true)"
+          head_type="$(git cat-file -t "${head_commit}:${go_mod_file}" 2>/dev/null || true)"
+
+          if [[ -z "$base_type" && -z "$head_type" ]]; then
+            echo "$go_mod_file does not exist at either commit." >&2
+            exit 1
+          fi
+
+          if [[ -n "$base_type" && "$base_type" != blob ]]; then
+            echo "$go_mod_file is not a file at commit $base_commit" >&2
+            exit 1
+          fi
+
+          if [[ -n "$head_type" && "$head_type" != blob ]]; then
+            echo "$go_mod_file is not a file at commit $head_commit" >&2
+            exit 1
+          fi
 
           tmp_dir="$(mktemp -d)"
           trap 'rm -rf "$tmp_dir"' EXIT
 
-          git show "${base_commit}:${go_mod_file}" >"$tmp_dir/base.mod"
-          git show "${head_commit}:${go_mod_file}" >"$tmp_dir/head.mod"
-
           # Direct requirements omit Indirect from `go mod edit -json`, so
           # `.Indirect != true` intentionally includes only direct modules.
-          go mod edit -json "$tmp_dir/base.mod" |
-            jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/base.json"
+          if [[ "$base_type" == blob ]]; then
+            git show "${base_commit}:${go_mod_file}" >"$tmp_dir/base.mod"
+            go mod edit -json "$tmp_dir/base.mod" |
+              jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/base.json"
+          else
+            echo '[]' >"$tmp_dir/base.json"
+          fi
 
-          go mod edit -json "$tmp_dir/head.mod" |
-            jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/head.json"
+          if [[ "$head_type" == blob ]]; then
+            git show "${head_commit}:${go_mod_file}" >"$tmp_dir/head.mod"
+            go mod edit -json "$tmp_dir/head.mod" |
+              jq '[.Require[]? | select(.Indirect != true)]' >"$tmp_dir/head.json"
+          else
+            echo '[]' >"$tmp_dir/head.json"
+          fi
 
           jq -n \
             --arg base_ref "$base_ref" \

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -20,3 +20,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Check workflow files
         uses: raven-actions/actionlint@v2
+      - name: Set up go
+        uses: actions/setup-go@v7
+        with:
+          go-version: 1.26.5
+          cache: false
+      - name: Test Go dependency diff workflow
+        run: sh test/go-dependency-diff.sh

--- a/README.md
+++ b/README.md
@@ -143,9 +143,16 @@ between two Git commits. It writes a readable job summary and exposes the
 requirements, `go.sum`, `replace` or `tool` directives, the Go version, or
 compiled binary size.
 
-On pull requests, the base and head refs default to the pull request commits.
-Callers for other events must pass `base-ref`; they can optionally override
-`head-ref`, which otherwise defaults to `GITHUB_SHA`.
+On pull requests, the workflow compares the head commit with its merge base
+against the pull request base. Callers for other events must pass `base-ref`;
+plain branch names fall back to their `origin/` remote-tracking branch. Callers
+can optionally override `head-ref`, which otherwise defaults to `GITHUB_SHA`.
+If the module file exists at only one commit, the missing side is treated as an
+empty dependency set so module creation and deletion remain reportable changes.
+
+The runner must provide `git` and `jq`; the selected Go version is installed by
+`actions/setup-go`. The workflow checks these commands up front and reports a
+clear error when a prerequisite is unavailable on a self-hosted runner.
 
 For example, a repository such as Emaia with its Go module under `backend/`
 can call it with:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ requirements, `go.sum`, `replace` or `tool` directives, the Go version, or
 compiled binary size.
 
 On pull requests, the workflow compares the head commit with its merge base
-against the pull request base. Callers for other events must pass `base-ref`;
+against the selected base, including when `base-ref` is explicitly supplied.
+The JSON report exposes the selected ref's resolved commit as
+`base_ref_commit`, the actual comparison commit as `base_commit`, and sets
+`base_is_merge_base` to `true`. Callers for other events must pass `base-ref`;
 plain branch names fall back to their `origin/` remote-tracking branch. Callers
 can optionally override `head-ref`, which otherwise defaults to `GITHUB_SHA`.
 If the module file exists at only one commit, the missing side is treated as an

--- a/README.md
+++ b/README.md
@@ -135,6 +135,36 @@ jobs:
       go-fix-check: false
 ```
 
+## Compare direct Go dependencies
+
+`go-dependency-diff.yaml` compares direct requirements in a Go module file
+between two Git commits. It writes a readable job summary and exposes the
+`has_changes` and `report_json` workflow outputs. It does not compare indirect
+requirements, `go.sum`, `replace` or `tool` directives, the Go version, or
+compiled binary size.
+
+On pull requests, the base and head refs default to the pull request commits.
+Callers for other events must pass `base-ref`; they can optionally override
+`head-ref`, which otherwise defaults to `GITHUB_SHA`.
+
+For example, a repository such as Emaia with its Go module under `backend/`
+can call it with:
+
+```yaml
+jobs:
+  dependency-diff:
+    uses: ectobit/reusable-workflows/.github/workflows/go-dependency-diff.yaml@main
+    with:
+      runner: '["self-hosted","linux","emaia"]'
+      go-version: 1.26.5
+      go-toolchain: local
+      go-mod-file: backend/go.mod
+      fail-on-changes: false
+```
+
+Set `fail-on-changes: true` only when any direct dependency change should be a
+blocking policy violation. The default is report-only.
+
 ## Check and release Helm charts
 
 `chart.yaml` can run Helm lint, a default `helm template`, caller-supplied render/check commands, and optional chart publishing. Existing ChartMuseum callers continue to work. OCI publishing is available with `release-target: oci`.

--- a/test/go-dependency-diff.sh
+++ b/test/go-dependency-diff.sh
@@ -1,0 +1,267 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)"
+workflow="$repo_root/.github/workflows/go-dependency-diff.yaml"
+test_case="${1:-all}"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+diff_script="$tmp_root/go-dependency-diff.sh"
+awk '
+  $0 == "        id: diff" { found_step = 1; next }
+  found_step && $0 == "        run: |" { found_run = 1; next }
+  found_run && $0 ~ /^      - name:/ { exit }
+  found_run { sub(/^          /, ""); print }
+' "$workflow" >"$diff_script"
+
+if [ ! -s "$diff_script" ]; then
+  echo "Could not extract the dependency diff script from $workflow" >&2
+  exit 1
+fi
+
+new_repo() {
+  name="$1"
+  repo="$tmp_root/$name"
+  git init -q -b main "$repo"
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name Test
+  printf '%s\n' "$repo"
+}
+
+write_go_mod() {
+  path="$1"
+  module="$2"
+  version="$3"
+  dependency="$4"
+
+  mkdir -p "$(dirname "$path")"
+  {
+    echo "module $module"
+    echo
+    echo "go 1.26.5"
+    if [ -n "$dependency" ]; then
+      echo
+      echo "require example.com/dependency $version"
+    fi
+  } >"$path"
+}
+
+commit_all() {
+  repo="$1"
+  message="$2"
+  git -C "$repo" add .
+  git -C "$repo" commit -q -m "$message"
+}
+
+run_diff() {
+  repo="$1"
+  base_ref="$2"
+  head_ref="$3"
+  event_base_sha="$4"
+  event_head_sha="$5"
+  go_mod_file="$6"
+  output="$7"
+  summary="$8"
+
+  (
+    cd "$repo"
+    INPUT_BASE_REF="$base_ref" \
+      INPUT_HEAD_REF="$head_ref" \
+      INPUT_GO_MOD_FILE="$go_mod_file" \
+      EVENT_BASE_SHA="$event_base_sha" \
+      EVENT_HEAD_SHA="$event_head_sha" \
+      GITHUB_SHA="$(git rev-parse HEAD)" \
+      GITHUB_OUTPUT="$output" \
+      GITHUB_STEP_SUMMARY="$summary" \
+      GOTOOLCHAIN=local \
+      bash "$diff_script"
+  )
+}
+
+assert_output_value() {
+  output="$1"
+  name="$2"
+  expected="$3"
+  actual="$(sed -n "s/^${name}=//p" "$output")"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Expected $name=$expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+test_pull_request_uses_merge_base() {
+  repo="$(new_repo merge-base)"
+  write_go_mod "$repo/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+
+  git -C "$repo" switch -q -c feature
+  echo feature >"$repo/feature.txt"
+  commit_all "$repo" feature
+  feature_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" switch -q main
+  write_go_mod "$repo/go.mod" example.com/app v1.1.0 yes
+  commit_all "$repo" main-update
+  main_sha="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" switch -q feature
+
+  output="$tmp_root/merge-base.output"
+  summary="$tmp_root/merge-base.summary"
+  run_diff "$repo" '' '' "$main_sha" "$feature_sha" go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes false
+}
+
+test_missing_base_is_empty() {
+  repo="$(new_repo missing-base)"
+  echo base >"$repo/README.md"
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" add-module
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/missing-base.output"
+  summary="$tmp_root/missing-base.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  report="$(sed -n 's/^report_json=//p' "$output")"
+  actual="$(printf '%s' "$report" | jq -r '[.counts.added, .counts.removed, .counts.updated] | join(",")')"
+  [ "$actual" = '1,0,0' ] || {
+    echo "Expected one added dependency, got $actual" >&2
+    exit 1
+  }
+}
+
+test_missing_head_is_empty() {
+  repo="$(new_repo missing-head)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" rm -q backend/go.mod
+  commit_all "$repo" remove-module
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/missing-head.output"
+  summary="$tmp_root/missing-head.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  report="$(sed -n 's/^report_json=//p' "$output")"
+  actual="$(printf '%s' "$report" | jq -r '[.counts.added, .counts.removed, .counts.updated] | join(",")')"
+  [ "$actual" = '0,1,0' ] || {
+    echo "Expected one removed dependency, got $actual" >&2
+    exit 1
+  }
+}
+
+test_both_missing_fails_clearly() {
+  repo="$(new_repo both-missing)"
+  echo base >"$repo/README.md"
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+  echo head >>"$repo/README.md"
+  commit_all "$repo" head
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/both-missing.output"
+  summary="$tmp_root/both-missing.summary"
+  error="$tmp_root/both-missing.error"
+  if run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary" 2>"$error"; then
+    echo "Expected missing module files to fail" >&2
+    exit 1
+  fi
+  grep -q 'does not exist at either commit' "$error" || {
+    echo "Expected a clear both-missing error" >&2
+    cat "$error" >&2
+    exit 1
+  }
+}
+
+test_directory_path_fails_clearly() {
+  repo="$(new_repo directory-path)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/directory-path.output"
+  summary="$tmp_root/directory-path.summary"
+  error="$tmp_root/directory-path.error"
+  if run_diff "$repo" "$sha" "$sha" '' '' backend "$output" "$summary" 2>"$error"; then
+    echo "Expected a directory module path to fail" >&2
+    exit 1
+  fi
+  grep -q 'is not a file at commit' "$error" || {
+    echo "Expected a clear non-file error" >&2
+    cat "$error" >&2
+    exit 1
+  }
+}
+
+test_plain_branch_falls_back_to_origin() {
+  repo="$(new_repo remote-branch)"
+  write_go_mod "$repo/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  sha="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" update-ref refs/remotes/origin/main "$sha"
+  git -C "$repo" switch -q -c feature
+  git -C "$repo" branch -q -D main
+
+  output="$tmp_root/remote-branch.output"
+  summary="$tmp_root/remote-branch.summary"
+  run_diff "$repo" main HEAD '' '' go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes false
+}
+
+test_missing_jq_fails_clearly() {
+  bin="$tmp_root/bin"
+  mkdir -p "$bin"
+  ln -s "$(command -v git)" "$bin/git"
+  ln -s "$(command -v go)" "$bin/go"
+  error="$tmp_root/missing-jq.error"
+
+  if PATH="$bin" \
+    INPUT_BASE_REF=HEAD \
+    INPUT_HEAD_REF=HEAD \
+    INPUT_GO_MOD_FILE=go.mod \
+    EVENT_BASE_SHA='' \
+    EVENT_HEAD_SHA='' \
+    GITHUB_SHA=HEAD \
+    GITHUB_OUTPUT="$tmp_root/missing-jq.output" \
+    GITHUB_STEP_SUMMARY="$tmp_root/missing-jq.summary" \
+    GOTOOLCHAIN=local \
+    /bin/bash "$diff_script" 2>"$error"; then
+    echo "Expected a missing jq command to fail" >&2
+    exit 1
+  fi
+
+  grep -q 'Missing required command: jq' "$error" || {
+    echo "Expected a clear missing-jq error" >&2
+    cat "$error" >&2
+    exit 1
+  }
+}
+
+run_test() {
+  case "$1" in
+    merge-base) test_pull_request_uses_merge_base ;;
+    missing-base) test_missing_base_is_empty ;;
+    missing-head) test_missing_head_is_empty ;;
+    both-missing) test_both_missing_fails_clearly ;;
+    directory-path) test_directory_path_fails_clearly ;;
+    remote-branch) test_plain_branch_falls_back_to_origin ;;
+    missing-jq) test_missing_jq_fails_clearly ;;
+    *)
+      echo "Unknown test case: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [ "$test_case" = all ]; then
+  for name in merge-base missing-base missing-head both-missing directory-path remote-branch missing-jq; do
+    run_test "$name"
+  done
+else
+  run_test "$test_case"
+fi

--- a/test/go-dependency-diff.sh
+++ b/test/go-dependency-diff.sh
@@ -63,6 +63,7 @@ run_diff() {
   go_mod_file="$6"
   output="$7"
   summary="$8"
+  fail_on_changes="${9:-false}"
 
   if [ -n "$event_base_sha" ]; then
     event_name=pull_request
@@ -78,12 +79,37 @@ run_diff() {
       EVENT_BASE_SHA="$event_base_sha" \
       EVENT_HEAD_SHA="$event_head_sha" \
       EVENT_NAME="$event_name" \
+      INPUT_FAIL_ON_CHANGES="$fail_on_changes" \
       GITHUB_SHA="$(git rev-parse HEAD)" \
       GITHUB_OUTPUT="$output" \
       GITHUB_STEP_SUMMARY="$summary" \
       GOTOOLCHAIN=local \
       bash "$diff_script"
   )
+}
+
+assert_report() {
+  output="$1"
+  filter="$2"
+  description="$3"
+  report="$(sed -n 's/^report_json=//p' "$output")"
+
+  if ! printf '%s' "$report" | jq -e "$filter" >/dev/null; then
+    echo "Report did not contain $description:" >&2
+    printf '%s\n' "$report" >&2
+    exit 1
+  fi
+}
+
+assert_summary_contains() {
+  summary="$1"
+  expected="$2"
+
+  if ! grep -Fq -- "$expected" "$summary"; then
+    echo "Summary did not contain: $expected" >&2
+    cat "$summary" >&2
+    exit 1
+  fi
 }
 
 assert_output_value() {
@@ -148,6 +174,136 @@ test_explicit_pull_request_base_uses_merge_base() {
   output="$tmp_root/explicit-merge-base.output"
   summary="$tmp_root/explicit-merge-base.summary"
   run_diff "$repo" "$main_sha" '' "$main_sha" "$feature_sha" go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes false
+}
+
+test_existing_module_is_unchanged() {
+  repo="$(new_repo unchanged)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  echo unchanged >"$repo/README.md"
+  commit_all "$repo" unrelated-change
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/unchanged.output"
+  summary="$tmp_root/unchanged.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes false
+  assert_report "$output" '
+    .counts == {base_direct: 1, head_direct: 1, added: 0, removed: 0, updated: 0} and
+    .added == [] and .removed == [] and .updated == []
+  ' 'an unchanged direct dependency set'
+  assert_summary_contains "$summary" '| Updated | 0 |'
+  assert_summary_contains "$summary" '_None_'
+}
+
+test_existing_module_adds_dependency() {
+  repo="$(new_repo added)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  echo 'require example.com/added v1.2.0' >>"$repo/backend/go.mod"
+  commit_all "$repo" add-dependency
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/added.output"
+  summary="$tmp_root/added.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes true
+  assert_report "$output" '
+    .counts == {base_direct: 1, head_direct: 2, added: 1, removed: 0, updated: 0} and
+    .added == [{module: "example.com/added", version: "v1.2.0"}] and
+    .removed == [] and .updated == []
+  ' 'one added direct dependency'
+  assert_summary_contains "$summary" "- \`example.com/added\` \`v1.2.0\`"
+}
+
+test_existing_module_removes_dependency() {
+  repo="$(new_repo removed)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  echo 'require example.com/removed v1.2.0' >>"$repo/backend/go.mod"
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" remove-dependency
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/removed.output"
+  summary="$tmp_root/removed.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes true
+  assert_report "$output" '
+    .counts == {base_direct: 2, head_direct: 1, added: 0, removed: 1, updated: 0} and
+    .added == [] and
+    .removed == [{module: "example.com/removed", version: "v1.2.0"}] and
+    .updated == []
+  ' 'one removed direct dependency'
+  assert_summary_contains "$summary" "- \`example.com/removed\` \`v1.2.0\`"
+}
+
+test_existing_module_updates_dependency() {
+  repo="$(new_repo updated)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.1.0 yes
+  commit_all "$repo" update-dependency
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/updated.output"
+  summary="$tmp_root/updated.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes true
+  assert_report "$output" '
+    .counts == {base_direct: 1, head_direct: 1, added: 0, removed: 0, updated: 1} and
+    .added == [] and .removed == [] and
+    .updated == [{module: "example.com/dependency", from: "v1.0.0", to: "v1.1.0"}]
+  ' 'one updated direct dependency'
+  assert_summary_contains "$summary" "- \`example.com/dependency\` \`v1.0.0\` → \`v1.1.0\`"
+}
+
+test_fail_on_changes_rejects_dependency_update() {
+  repo="$(new_repo fail-on-changes)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.1.0 yes
+  commit_all "$repo" update-dependency
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/fail-on-changes.output"
+  summary="$tmp_root/fail-on-changes.summary"
+  error="$tmp_root/fail-on-changes.error"
+  if run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary" true 2>"$error"; then
+    echo "Expected fail-on-changes to reject a dependency update" >&2
+    exit 1
+  fi
+  grep -q 'Direct Go dependency changes were detected.' "$error" || {
+    echo "Expected a clear dependency-policy error" >&2
+    cat "$error" >&2
+    exit 1
+  }
+}
+
+test_fail_on_changes_allows_unchanged_module() {
+  repo="$(new_repo fail-on-unchanged)"
+  write_go_mod "$repo/backend/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  echo unchanged >"$repo/README.md"
+  commit_all "$repo" unrelated-change
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  output="$tmp_root/fail-on-unchanged.output"
+  summary="$tmp_root/fail-on-unchanged.summary"
+  run_diff "$repo" "$base_sha" "$head_sha" '' '' backend/go.mod "$output" "$summary" true
   assert_output_value "$output" has_changes false
 }
 
@@ -284,6 +440,12 @@ run_test() {
   case "$1" in
     merge-base) test_pull_request_uses_merge_base ;;
     explicit-merge-base) test_explicit_pull_request_base_uses_merge_base ;;
+    unchanged) test_existing_module_is_unchanged ;;
+    added) test_existing_module_adds_dependency ;;
+    removed) test_existing_module_removes_dependency ;;
+    updated) test_existing_module_updates_dependency ;;
+    fail-on-changes) test_fail_on_changes_rejects_dependency_update ;;
+    fail-on-unchanged) test_fail_on_changes_allows_unchanged_module ;;
     missing-base) test_missing_base_is_empty ;;
     missing-head) test_missing_head_is_empty ;;
     both-missing) test_both_missing_fails_clearly ;;
@@ -298,7 +460,7 @@ run_test() {
 }
 
 if [ "$test_case" = all ]; then
-  for name in merge-base explicit-merge-base missing-base missing-head both-missing directory-path remote-branch missing-jq; do
+  for name in merge-base explicit-merge-base unchanged added removed updated fail-on-changes fail-on-unchanged missing-base missing-head both-missing directory-path remote-branch missing-jq; do
     run_test "$name"
   done
 else

--- a/test/go-dependency-diff.sh
+++ b/test/go-dependency-diff.sh
@@ -64,6 +64,12 @@ run_diff() {
   output="$7"
   summary="$8"
 
+  if [ -n "$event_base_sha" ]; then
+    event_name=pull_request
+  else
+    event_name=workflow_dispatch
+  fi
+
   (
     cd "$repo"
     INPUT_BASE_REF="$base_ref" \
@@ -71,6 +77,7 @@ run_diff() {
       INPUT_GO_MOD_FILE="$go_mod_file" \
       EVENT_BASE_SHA="$event_base_sha" \
       EVENT_HEAD_SHA="$event_head_sha" \
+      EVENT_NAME="$event_name" \
       GITHUB_SHA="$(git rev-parse HEAD)" \
       GITHUB_OUTPUT="$output" \
       GITHUB_STEP_SUMMARY="$summary" \
@@ -110,6 +117,37 @@ test_pull_request_uses_merge_base() {
   output="$tmp_root/merge-base.output"
   summary="$tmp_root/merge-base.summary"
   run_diff "$repo" '' '' "$main_sha" "$feature_sha" go.mod "$output" "$summary"
+  assert_output_value "$output" has_changes false
+
+  report="$(sed -n 's/^report_json=//p' "$output")"
+  merge_base="$(git -C "$repo" merge-base "$main_sha" "$feature_sha")"
+  actual="$(printf '%s' "$report" | jq -r '[.base_is_merge_base, .base_ref_commit, .base_commit] | join(",")')"
+  expected="true,$main_sha,$merge_base"
+  [ "$actual" = "$expected" ] || {
+    echo "Expected merge-base metadata $expected, got $actual" >&2
+    exit 1
+  }
+}
+
+test_explicit_pull_request_base_uses_merge_base() {
+  repo="$(new_repo explicit-merge-base)"
+  write_go_mod "$repo/go.mod" example.com/app v1.0.0 yes
+  commit_all "$repo" base
+
+  git -C "$repo" switch -q -c feature
+  echo feature >"$repo/feature.txt"
+  commit_all "$repo" feature
+  feature_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" switch -q main
+  write_go_mod "$repo/go.mod" example.com/app v1.1.0 yes
+  commit_all "$repo" main-update
+  main_sha="$(git -C "$repo" rev-parse HEAD)"
+  git -C "$repo" switch -q feature
+
+  output="$tmp_root/explicit-merge-base.output"
+  summary="$tmp_root/explicit-merge-base.summary"
+  run_diff "$repo" "$main_sha" '' "$main_sha" "$feature_sha" go.mod "$output" "$summary"
   assert_output_value "$output" has_changes false
 }
 
@@ -245,6 +283,7 @@ test_missing_jq_fails_clearly() {
 run_test() {
   case "$1" in
     merge-base) test_pull_request_uses_merge_base ;;
+    explicit-merge-base) test_explicit_pull_request_base_uses_merge_base ;;
     missing-base) test_missing_base_is_empty ;;
     missing-head) test_missing_head_is_empty ;;
     both-missing) test_both_missing_fails_clearly ;;
@@ -259,7 +298,7 @@ run_test() {
 }
 
 if [ "$test_case" = all ]; then
-  for name in merge-base missing-base missing-head both-missing directory-path remote-branch missing-jq; do
+  for name in merge-base explicit-merge-base missing-base missing-head both-missing directory-path remote-branch missing-jq; do
     run_test "$name"
   done
 else


### PR DESCRIPTION
## Summary

- add a reusable workflow that compares direct Go dependencies between two Git revisions
- support nested module files, configurable runners and Go toolchains, JSON outputs, job summaries, and optional policy enforcement
- document usage for Emaia's `backend/go.mod` layout

## Why

Emaia needs a reusable, read-only way to show direct dependency additions, removals, and version updates during pull request validation without coupling this analysis to the existing Go check or dependency update workflows.

## Validation

- `actionlint .github/workflows/*.yaml`
- ShellCheck on the embedded Bash comparison script
- behavioral tests against Emaia history covering unchanged, added, removed, and updated direct dependencies
- `git diff --check`
